### PR TITLE
changed 'host' to 'hostname' for the db array

### DIFF
--- a/src/aimeos-settings.php
+++ b/src/aimeos-settings.php
@@ -26,7 +26,7 @@ return array(
 	'resource' => array(
 		'db' => array(
 			'adapter' => 'mysql',
-			'host' => 'localhost',
+			'hostname' => 'localhost',
 			'port' => '',
 			'database' => 'slim',
 			'username' => 'root',


### PR DESCRIPTION
I don't know if this is php-bound or database server bound.
I'm on Centos 7 using php7 and mariadb10.1

it only worked after changing 'host' to 'hostname'
